### PR TITLE
Compile snippet code with filename information to allow debug

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -157,6 +157,7 @@ def makeSnippetFunction(snippet):
 
         (snippetDescription, snippetKeys, snippetCode) = loadSnippetFromFile(snippet)
         snippetCode = "# \n# \n" + snippetCode
+        snippetCode = compile(snippetCode, snippet, 'exec')
         actionText = actionFromSnippet(snippet, snippetDescription)
         executeSnippet(snippetCode, actionText)
     return lambda context: execute()


### PR DESCRIPTION
PyCharm needs to know which file the code came from so it can set breakpoints.