### PR TITLE
Use save method instead of re-implementing the save functionality

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -593,13 +593,7 @@ class Snippets(QDialog):
         actionText = actionFromSnippet(self.currentFile, self.snippetDescription.text())
         UIActionHandler.globalActions().executeAction(actionText, self.context)
 
-        log_debug("Snippets: Saving snippet %s" % self.currentFile)
-        outputSnippet = codecs.open(self.currentFile, "w", "utf-8")
-        outputSnippet.write("#" + self.snippetDescription.text() + "\n")
-        outputSnippet.write("#" + self.keySequenceEdit.keySequence().toString() + "\n")
-        outputSnippet.write(self.edit.toPlainText())
-        outputSnippet.close()
-        self.registerAllSnippets()
+        self.save()
 
     def export(self):
         if self.snippetChanged():


### PR DESCRIPTION
I'm monkey patching snippets from my plugin [frinja](https://github.com/dzervas/frinja) and that specific piece of code gets in my way - I'd have to patch the whole run method

For you, it doesn't change a thing, the `save` method does exactly the same thing