### PR TITLE
Make current_il_instructions available in snippets

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -166,13 +166,20 @@ def setupGlobals(uiactioncontext, uicontext):
             active_il_function = uiactioncontext.function.hlil_if_available.ssa_form
 
         if active_il_function:
+            il_start = view.getSelectionStartILInstructionIndex()
+
             snippetGlobals['current_il_function'] = active_il_function
             snippetGlobals['current_il_instruction'] = active_il_function[active_il_index]
             snippetGlobals["current_il_basic_block"] = active_il_function[active_il_index].il_basic_block
+            snippetGlobals['current_il_instructions'] = (active_il_function[i] for i in range(
+                min(il_start, active_il_index),
+                max(il_start, active_il_index) + 1)
+            )
         else:
             snippetGlobals['current_il_function'] = None
             snippetGlobals['current_il_instruction'] = None
             snippetGlobals["current_il_basic_block"] = None
+            snippetGlobals['current_il_instructions'] = None
 
         var = None
         if uiactioncontext is not None:


### PR DESCRIPTION
Creates `current_il_instructions` as a generator over the selected instructions, same as the implementation in https://github.com/Vector35/binaryninja-api/blob/a542d0c9cd33fed5919c3cd9d598bb8d1a300ae8/python/scriptingprovider.py#L957C1-L960C1.