### PR TITLE
Fix bug when running snippet on the function proto

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -165,21 +165,22 @@ def setupGlobals(uiactioncontext, uicontext):
         elif ilType == FunctionGraphType.HighLevelILSSAFormFunctionGraph and uiactioncontext.function and uiactioncontext.function.hlil_if_available:
             active_il_function = uiactioncontext.function.hlil_if_available.ssa_form
 
+        snippetGlobals['current_il_function'] = None
+        snippetGlobals['current_il_instruction'] = None
+        snippetGlobals["current_il_basic_block"] = None
+        snippetGlobals['current_il_instructions'] = None
         if active_il_function:
             il_start = view.getSelectionStartILInstructionIndex()
 
             snippetGlobals['current_il_function'] = active_il_function
-            snippetGlobals['current_il_instruction'] = active_il_function[active_il_index]
-            snippetGlobals["current_il_basic_block"] = active_il_function[active_il_index].il_basic_block
-            snippetGlobals['current_il_instructions'] = (active_il_function[i] for i in range(
-                min(il_start, active_il_index),
-                max(il_start, active_il_index) + 1)
-            )
-        else:
-            snippetGlobals['current_il_function'] = None
-            snippetGlobals['current_il_instruction'] = None
-            snippetGlobals["current_il_basic_block"] = None
-            snippetGlobals['current_il_instructions'] = None
+
+            if active_il_index in active_il_function:
+                snippetGlobals['current_il_instruction'] = active_il_function[active_il_index]
+                snippetGlobals["current_il_basic_block"] = active_il_function[active_il_index].il_basic_block
+                snippetGlobals['current_il_instructions'] = (active_il_function[i] for i in range(
+                    min(il_start, active_il_index),
+                    max(il_start, active_il_index) + 1)
+                )
 
         var = None
         if uiactioncontext is not None:

--- a/__init__.py
+++ b/__init__.py
@@ -174,7 +174,7 @@ def setupGlobals(uiactioncontext, uicontext):
 
             snippetGlobals['current_il_function'] = active_il_function
 
-            if active_il_index in active_il_function:
+            if active_il_index < len(active_il_function):
                 snippetGlobals['current_il_instruction'] = active_il_function[active_il_index]
                 snippetGlobals["current_il_basic_block"] = active_il_function[active_il_index].il_basic_block
                 snippetGlobals['current_il_instructions'] = (active_il_function[i] for i in range(


### PR DESCRIPTION
When running a snippet on the function prototype, `active_il_index` is not part of `active_il_function` because we __are__ in the function but __not__ in any code yet.